### PR TITLE
chore(ci): add release candidate branching

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,6 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "poetry"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -25,4 +20,15 @@ updates:
     commit-message:
       # Prefix all commit messages with "chore: "
       prefix: "chore"
-
+    groups:
+      ai-dial-ci:
+        applies-to: version-updates
+        patterns:
+          - "epam/ai-dial-ci/*"
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "epam/ai-dial-ci/*"
+    open-pull-requests-limit: 10

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -1,9 +1,9 @@
 name: Deploy development
 
 on:
-  workflow_dispatch: 
-  registry_package: 
-  workflow_run: 
+  workflow_dispatch: # manual run
+  registry_package: # on new package version (main path)
+  workflow_run: # HACK: redundant trigger to mitigate GitHub's huge delays in registry_package event processing
     workflows: ["Release Workflow"]
     types:
       - completed
@@ -14,7 +14,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.registry_package.package_version.container_metadata.tag.name == 'development' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'development')
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@2.6.0
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.0.0
     with:
       gitlab-project-id: "2350"
     secrets:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,12 +7,14 @@ on:
       - edited
       - reopened
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@2.6.0
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.0.0
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,5 +10,5 @@ concurrency:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/python_docker_pr.yml@2.6.0
+    uses: epam/ai-dial-ci/.github/workflows/python_docker_pr.yml@4.0.0
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release Workflow
 on:
   push:
     branches: [development, release-*]
+  workflow_dispatch:
+    inputs:
+      promote:
+        type: boolean
+        default: false
+        description: Promote release to stable (for release-* branches only)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,5 +16,7 @@ concurrency:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/python_docker_release.yml@2.6.0
+    uses: epam/ai-dial-ci/.github/workflows/python_docker_release.yml@4.0.0
+    with:
+      promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aidial-app-builder-python"
-version = "0.2.0rc"
+version = "0.0.0"
 description = "DIAL Application Controller builder template for python"
 authors = ["EPAM RAIL <SpecialEPM-DIALDevTeam@epam.com>"]
 homepage = "https://epam-rail.com"


### PR DESCRIPTION
- bump epam/ai-dial-ci workflow version and add promote input = enable release candidates for the given repo
- drop version in pyproject.toml file to dev marker (`0.0.0`)
- minor workflow-related fixes & alignments