### PR TITLE
ci: re-use venv

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,10 @@
+import os
+
 import nox
 
 nox.options.reuse_existing_virtualenvs = True
+if os.environ.get("CI"):
+    nox.options.default_venv_backend = "none"
 
 SRC = "."
 


### PR DESCRIPTION
CI speed-up:

- instruct **nox** to reuse the existing venv (created by **poetry**) instead of building a fresh one per session.

For local execution everything stays the same